### PR TITLE
comment the change of work.dir

### DIFF
--- a/generateTrainAndTestBulkProbMatrix.R
+++ b/generateTrainAndTestBulkProbMatrix.R
@@ -66,7 +66,7 @@ prefix <- args$prefix
 
 dir.create(outputPath)
 dir.create(file.path(outputPath,"Plots"),showWarnings = F)
-setwd(outputPath)
+##setwd(outputPath) #files are given with relative to w.d path
 
 cat("Load Cells Metadata\n")
 if (grepl(".tsv",cellsMetadataFile)) {


### PR DESCRIPTION
required files in input are given  relative to work.dir path so it will pop-up error if setwd(outputPath) is run.